### PR TITLE
feat: resolve (#53) by removing PointerEvent usage

### DIFF
--- a/js/dragger.js
+++ b/js/dragger.js
@@ -20,12 +20,18 @@
 var downEvent = 'mousedown';
 var moveEvent = 'mousemove';
 var upEvent = 'mouseup';
-if ( window.PointerEvent ) {
-  // PointerEvent, Chrome
-  downEvent = 'pointerdown';
-  moveEvent = 'pointermove';
-  upEvent = 'pointerup';
-} else if ( 'ontouchstart' in window ) {
+/**
+ * Potential bug with PointerEvent implementation
+ * pointermove doesn't register for every move and
+ * neither does pointerup
+ */
+// if ( window.PointerEvent ) {
+//   // PointerEvent, Chrome
+//   downEvent = 'pointerdown';
+//   moveEvent = 'pointermove';
+//   upEvent = 'pointerup';
+// } else
+if ( 'ontouchstart' in window ) {
   // Touch Events, iOS Safari
   downEvent = 'touchstart';
   moveEvent = 'touchmove';
@@ -78,7 +84,7 @@ Dragger.prototype.ontouchstart = function( event ) {
 };
 
 Dragger.prototype.dragStart = function( event, pointer ) {
-  event.preventDefault();
+  if (downEvent === 'pointerdown') event.preventDefault();
   this.dragStartX = pointer.pageX;
   this.dragStartY = pointer.pageY;
   window.addEventListener( moveEvent, this );
@@ -97,7 +103,7 @@ Dragger.prototype.onpointermove = function( event ) {
 };
 
 Dragger.prototype.dragMove = function( event, pointer ) {
-  event.preventDefault();
+  if (downEvent === 'pointerdown') event.preventDefault();
   var moveX = pointer.pageX - this.dragStartX;
   var moveY = pointer.pageY - this.dragStartY;
   this.onDragMove( pointer, moveX, moveY );


### PR DESCRIPTION
This likely isn't the best solution but does solve the dragging issues seen on Android Chrome, desktop emulator etc.

Debugging the issue found that `pointerdown` fires. `pointermove` only fires a finite number of times and then `pointerup` never fires. I'm not too sure why this is. I'd prefer to get `PointerEvent` working as expected. However, removing the condition and falling onto the touch events does get drag behaviour working across all devices from what I can see 👍 

I've tested on device and also with USB debugging to try and see what is stopping the pointer events from firing.

Interested to see what the best way forward is with this one.