### PR TITLE
More accurate Z sorting of Shapes

### DIFF
--- a/js/cone.js
+++ b/js/cone.js
@@ -44,6 +44,19 @@ Cone.prototype.create = function(/* options */) {
   ];
 };
 
+Cone.prototype.updateSortValue = function() {
+  // call super
+  Ellipse.prototype.updateSortValue.apply( this, arguments );
+  var apexNormal = new Vector();
+  apexNormal.set( this.renderOrigin )
+    .subtract( this.apex.renderOrigin );
+  var apexAngleZ = Math.atan2( apexNormal.z, apexNormal.y );
+  apexAngleZ = utils.modulo( apexAngleZ, TAU );
+  //center of cone is one third of its length.
+  var apexZ = this.length/3 * Math.sin(apexAngleZ);
+  this.sortValue -= apexZ;
+};
+
 Cone.prototype.render = function( ctx, renderer ) {
   this.renderConeSurface( ctx, renderer );
   Ellipse.prototype.render.apply( this, arguments );

--- a/js/ellipse.js
+++ b/js/ellipse.js
@@ -58,17 +58,6 @@ Ellipse.prototype.setPath = function() {
   }
 };
 
-Ellipse.prototype.updateSortValue = function() {
-  Shape.prototype.updateSortValue.apply( this, arguments );
-  if ( this.quarters != 4 ) {
-    return;
-  }
-  // ellipse is self closing, do not count last point twice
-  var length = this.pathCommands.length;
-  var lastPoint = this.pathCommands[ length - 1 ].endRenderPoint;
-  this.sortValue -= lastPoint.z / length;
-};
-
 return Ellipse;
 
 }));

--- a/js/hemisphere.js
+++ b/js/hemisphere.js
@@ -20,6 +20,16 @@ var Hemisphere = Ellipse.subclass({
 
 var TAU = utils.TAU;
 
+Hemisphere.prototype.updateSortValue = function() {
+  // call super
+  Ellipse.prototype.updateSortValue.apply( this, arguments );
+  var contourAngleZ = Math.atan2( this.renderNormal.z, this.renderNormal.y );
+  contourAngleZ = utils.modulo( contourAngleZ, TAU );
+  //center of dome is half the radius.
+  var domeZ = this.diameter/2/2 * Math.sin(contourAngleZ);
+  this.sortValue -= domeZ;
+};
+
 Hemisphere.prototype.render = function( ctx, renderer ) {
   this.renderDome( ctx, renderer );
   // call super

--- a/js/rounded-rect.js
+++ b/js/rounded-rect.js
@@ -72,14 +72,6 @@ RoundedRect.prototype.setPath = function() {
   this.path = path;
 };
 
-RoundedRect.prototype.updateSortValue = function() {
-  Shape.prototype.updateSortValue.apply( this, arguments );
-  // ellipse is self closing, do not count last point twice
-  var length = this.pathCommands.length;
-  var lastPoint = this.pathCommands[ length - 1 ].endRenderPoint;
-  this.sortValue -= lastPoint.z / length;
-};
-
 return RoundedRect;
 
 }));

--- a/js/shape.js
+++ b/js/shape.js
@@ -115,11 +115,9 @@ Shape.prototype.updateSortValue = function() {
   var howManyPoints = this.pathCommands.length;
   var sortValueTotal = 0;
   var firstPoint = this.pathCommands[0].endRenderPoint;
-  var lastPoint = this.pathCommands[this.pathCommands.length - 1].endRenderPoint;
+  var lastPoint = this.pathCommands[this.pathCommands.length-1].endRenderPoint;
   if (howManyPoints > 2 &&
-      firstPoint.x === lastPoint.x &&
-      firstPoint.y === lastPoint.y &&
-      firstPoint.z === lastPoint.z) {
+      firstPoint.isSame(lastPoint)) {
     howManyPoints -= 1; // closed shape; ignore final point.
   }
   

--- a/js/shape.js
+++ b/js/shape.js
@@ -110,13 +110,25 @@ Shape.prototype.transform = function( translation, rotation, scale ) {
 
 
 Shape.prototype.updateSortValue = function() {
+  // average sort all z points.
+  // ignore the final point if it is a closed shape.
+  var howManyPoints = this.pathCommands.length;
   var sortValueTotal = 0;
-  this.pathCommands.forEach( function( command ) {
-    sortValueTotal += command.endRenderPoint.z;
-  });
-  // average sort value of all points
-  // def not geometrically correct, but works for me
-  this.sortValue = sortValueTotal / this.pathCommands.length;
+  var firstPoint = this.pathCommands[0].endRenderPoint;
+  var lastPoint = this.pathCommands[this.pathCommands.length - 1].endRenderPoint;
+  if (howManyPoints > 2 &&
+      firstPoint.x === lastPoint.x &&
+      firstPoint.y === lastPoint.y &&
+      firstPoint.z === lastPoint.z) {
+    howManyPoints -= 1; // closed shape; ignore final point.
+  }
+  
+  for (var i = 0; i < howManyPoints; i++) {
+      sortValueTotal += this.pathCommands[i].endRenderPoint.z;
+    }
+    // average sort value of all points
+    // def not geometrically correct, but works for me
+    this.sortValue = sortValueTotal / howManyPoints;
 };
 
 // ----- render ----- //

--- a/js/vector.js
+++ b/js/vector.js
@@ -75,6 +75,15 @@ function rotateProperty( vec, angle, propA, propB ) {
   vec[ propB ] = b*cos + a*sin;
 }
 
+Vector.prototype.isSame = function( pos ) {
+  if ( !pos ) {
+    return false;
+  }
+  return (this.x === pos.x &&
+          this.y === pos.y &&
+          this.z === pos.z);
+};
+
 Vector.prototype.add = function( pos ) {
   if ( !pos ) {
     return this;


### PR DESCRIPTION
Zdog now correctly discards the final overlapping point in a closed path. Fixes #26 for Ellipses, Rounded Rectangles, and custom path Shapes. Fixing that caused Z fighting with co-planar Hemispheres and Cones, so those now calculate a better average Z.