### PR TITLE
feat: resolve #53 by setting element touch-action: none;

### DIFF
--- a/js/illustration.js
+++ b/js/illustration.js
@@ -43,6 +43,9 @@ Illustration.prototype.create = function( options ) {
 
 Illustration.prototype.setElement = function( element ) {
   element = this.getQueryElement( element );
+  if (window.PointerEvent && element) {
+    element.style.touchAction = 'none';
+  }
   if ( !element ) {
     throw new Error( 'Zdog.Illustration element required. Set to ' + element );
   }


### PR DESCRIPTION
Not 100% sure if this is the right place to do it.

However can confirm that setting the `touchAction` style key to `none` does allow for `dragRotate` on all devices 🙌 Thanks for the fix!

Happy to move this code elsewhere or adjust accordingly 👍 