### PR TITLE
fix: Allow touch event when PointerEvent is not available

### DIFF
--- a/js/dragger.js
+++ b/js/dragger.js
@@ -52,8 +52,10 @@ Dragger.prototype.bindDrag = function( element ) {
     return;
   }
   // disable browser gestures #53
-  element.style.touchAction = 'none';
-  element.addEventListener( downEvent, this );
+  if (window.PointerEvent) {
+    element.style.touchAction = 'none';
+  }
+  element.addEventListener( downEvent, this, { passive: false } );
 };
 
 Dragger.prototype.getQueryElement = function( element ) {
@@ -84,7 +86,7 @@ Dragger.prototype.dragStart = function( event, pointer ) {
   event.preventDefault();
   this.dragStartX = pointer.pageX;
   this.dragStartY = pointer.pageY;
-  window.addEventListener( moveEvent, this );
+  window.addEventListener( moveEvent, this, { passive: false } );
   window.addEventListener( upEvent, this );
   this.onDragStart( pointer );
 };


### PR DESCRIPTION
- The current implementation applies `touch-action: none` without checking for `PointerEvent` support. 
- Doing so means that if `PointerEvent` isn't available, `ontouchstart` will never fire. Effectively blocking the use of `dragRotate` with no error to the user.
- This PR Adds a conditional where `touch-action: none` is being applied.
- Also, in the case of `downEvent === 'touchstart'`, use of `preventDefault` will throw log an error: `  Unable to preventDefault inside passive event listener due to target being treated as passive.` You can read about this here: https://www.chromestatus.com/features/5093566007214080. Essentially event listeners aren't passive by default. But when it comes to `touchstart` and `touchmove`, they are in some browsers.
- To avoid this, we can either wrap the `event.preventDefault()` call in a conditional based on the `downEvent` or explicitly set the event listener to `passive: false`. `passive: false` being the default in most cases and some browsers if the `downEvent` is `touchstart`/`touchmove` 👍 
- To test the current version to see the issue, set `window.PointerEvent = undefined;` in a demo:
```html
<script>
  window.PointerEvent = undefined;
</script>
```