### PR TITLE
WIP: Save/load graph JSON

### DIFF
--- a/js/anchor.js
+++ b/js/anchor.js
@@ -22,6 +22,7 @@ var onePoint = { x: 1, y: 1, z: 1 };
 function Anchor( options ) {
   this.create( options || {} );
 }
+Anchor.prototype.type = 'Anchor';
 
 Anchor.prototype.create = function( options ) {
   // set defaults & options

--- a/js/anchor.js
+++ b/js/anchor.js
@@ -212,6 +212,36 @@ Anchor.prototype.normalizeRotate = function() {
   this.rotate.y = utils.modulo( this.rotate.y, TAU );
   this.rotate.z = utils.modulo( this.rotate.z, TAU );
 };
+  
+Anchor.prototype.toJSON = function () {
+  var result = {};
+  var optionKeys = this.constructor.optionKeys;
+
+  [...optionKeys, 'children'].forEach(function (key) {
+    if (['addTo', 'dragRotate', 'element', 'resize'].includes(key)) return;
+    var value = this[key];
+    var defaults = this.constructor.defaults;
+
+    if (!['undefined', 'function'].includes(typeof value) && value !== defaults[key]) {
+      if (Array.isArray(value) && value.length === 0) {
+        return;
+      }
+      if (value.toJSON) {
+        var serialized = value.toJSON();
+        if (typeof serialized !== 'undefined') {
+          if (key === 'scale' && serialized === 1) {
+            return;
+          }
+          result[key] = serialized;
+        }
+      } else {
+        result[key] = value;
+      }
+    }
+  }, this);
+
+  return result;
+};
 
 // ----- subclass ----- //
 

--- a/js/anchor.js
+++ b/js/anchor.js
@@ -214,10 +214,16 @@ Anchor.prototype.normalizeRotate = function() {
 };
   
 Anchor.prototype.toJSON = function () {
-  var result = {};
-  var optionKeys = this.constructor.optionKeys;
+  var type = this.type;
+  var ignoreChildren = this.ignoreChildren || false;
+  var result = { type: type };
+  var optionKeys = [...this.constructor.optionKeys];
 
-  [...optionKeys, 'children'].forEach(function (key) {
+  if (!ignoreChildren) {
+    optionKeys = [...optionKeys, 'children'];
+  }
+
+  optionKeys.forEach(function ( key ) {
     if (['addTo', 'dragRotate', 'element', 'resize'].includes(key)) return;
     var value = this[key];
     var defaults = this.constructor.defaults;

--- a/js/boilerplate.js
+++ b/js/boilerplate.js
@@ -69,6 +69,10 @@ Zdog.easeInOut = function( alpha, power ) {
   curve /= 2;
   return isFirstHalf ? curve : 1 - curve;
 };
+  
+Zdog.exportGraph = function (model) {
+  return JSON.parse( JSON.stringify( model ) );
+}
 
 return Zdog;
 

--- a/js/box.js
+++ b/js/box.js
@@ -18,9 +18,10 @@
 // ----- BoxRect ----- //
 
 var BoxRect = Rect.subclass();
+
 // prevent double-creation in parent.copyGraph()
 // only create in Box.create()
-BoxRect.prototype.copyGraph = function() {};
+BoxRect.prototype.copyGraph = function () { };
 
 // ----- Box ----- //
 
@@ -40,6 +41,8 @@ boxDefaults.fill = true;
 delete boxDefaults.path;
 
 var Box = Anchor.subclass( boxDefaults );
+Box.prototype.type = 'Box';
+Box.prototype.ignoreChildren = true;
 
 var TAU = utils.TAU;
 

--- a/js/cone.js
+++ b/js/cone.js
@@ -20,6 +20,8 @@ var Cone = Ellipse.subclass({
   length: 1,
   fill: true,
 });
+  
+Cone.prototype.type = 'Cone';
 
 var TAU = utils.TAU;
 

--- a/js/cylinder.js
+++ b/js/cylinder.js
@@ -25,6 +25,8 @@ var CylinderGroup = Group.subclass({
   color: '#333',
   updateSort: true,
 });
+  
+CylinderGroup.prototype.type = 'CylinderGroup';
 
 CylinderGroup.prototype.create = function() {
   Group.prototype.create.apply( this, arguments );
@@ -96,6 +98,9 @@ var Cylinder = Shape.subclass({
   frontFace: undefined,
   fill: true,
 });
+  
+Cylinder.prototype.type = 'Cylinder';
+
 
 var TAU = utils.TAU;
 

--- a/js/ellipse.js
+++ b/js/ellipse.js
@@ -22,6 +22,8 @@ var Ellipse = Shape.subclass({
   quarters: 4,
   closed: false,
 });
+  
+Ellipse.prototype.type = 'Ellipse';
 
 Ellipse.prototype.setPath = function() {
   var width = this.width != undefined ? this.width : this.diameter;

--- a/js/group.js
+++ b/js/group.js
@@ -18,6 +18,9 @@ var Group = Anchor.subclass({
   updateSort: false,
   visible: true,
 });
+  
+Group.prototype.type = 'Group';
+
 
 // ----- update ----- //
 

--- a/js/hemisphere.js
+++ b/js/hemisphere.js
@@ -17,6 +17,8 @@
 var Hemisphere = Ellipse.subclass({
   fill: true,
 });
+  
+Hemisphere.prototype.type = 'Hemisphere';
 
 var TAU = utils.TAU;
 

--- a/js/illustration.js
+++ b/js/illustration.js
@@ -30,6 +30,8 @@ var Illustration = Anchor.subclass({
   onDragEnd: noop,
   onResize: noop,
 });
+  
+Illustration.prototype.type = 'Illustration';
 
 utils.extend( Illustration.prototype, Dragger.prototype );
 

--- a/js/polygon.js
+++ b/js/polygon.js
@@ -18,6 +18,8 @@ var Polygon = Shape.subclass({
   sides: 3,
   radius: 0.5,
 });
+  
+Polygon.prototype.type = 'Polygon';
 
 var TAU = utils.TAU;
 

--- a/js/rect.js
+++ b/js/rect.js
@@ -18,6 +18,8 @@ var Rect = Shape.subclass({
   width: 1,
   height: 1,
 });
+  
+Rect.prototype.type = 'Rect';
 
 Rect.prototype.setPath = function() {
   var x = this.width / 2;

--- a/js/rounded-rect.js
+++ b/js/rounded-rect.js
@@ -20,6 +20,8 @@ var RoundedRect = Shape.subclass({
   cornerRadius: 0.25,
   closed: false,
 });
+  
+RoundedRect.prototype.type = 'RoundedRect';
 
 RoundedRect.prototype.setPath = function() {
   /* eslint

--- a/js/shape.js
+++ b/js/shape.js
@@ -26,6 +26,8 @@ var Shape = Anchor.subclass({
   backface: true,
 });
 
+Shape.prototype.type = 'Shape';
+
 Shape.prototype.create = function( options ) {
   Anchor.prototype.create.call( this, options );
   this.updatePath();

--- a/js/vector.js
+++ b/js/vector.js
@@ -148,6 +148,28 @@ Vector.prototype.magnitude2d = function() {
 Vector.prototype.copy = function() {
   return new Vector( this );
 };
+  
+Vector.prototype.toJSON = function() {
+  var x = this.x;
+  var y = this.y;
+  var z = this.z;
+  
+  if ( x === y && y === z ) {
+    return ( x !== 0 ) ? x : undefined;
+  }
+
+  var obj = { x: x, y: y, z: z };
+  var result = {};
+  
+  Object.keys( obj ).forEach( function ( key ) {
+    var value = obj[ key ];
+    if ( value !== 0 ) {
+      result[ key ] = value;
+    }
+  })
+
+  return Object.keys( result ).length ? result : undefined;
+};
 
 return Vector;
 


### PR DESCRIPTION
#35 seemed like a fairly simple implementation, so I decided to take a crack at it. 

I understand that you may have different plans for this feature, but I figured this would open up a conversation about the possible implementation.

**Features**
* Adds serialization via a `toJSON` method on `Anchor` and `Vector`. This is natively called by `JSON.stringify`, so `JSON.stringify`ing an illustration will work as expected.
* Adds serialization util via `Zdog.exportGraph`. It's really just calling `JSON.parse(JSON.stringify(model))` but could be hand-rolled if you want.
* Adds a `type` property to each Zdog primitive. There may be a cleaner way to do this, but the JSON needs to store the primitive type as a string so that it can be rehydrated.
* Adds `importGraph` option to `Anchor` object. Users can pass in
    1. A JSON object generated by `Zdog.exportGraph`
    2. A `string` specifying a relative or absolute path to a `json` file. This seemed like a cool feature which would allow people to easily share models via url. It's just a simple `fetch` call for modern browsers, but I realize that this may introduce some unwanted overhead for legacy browsers.

**In Progress**
* Code style (Need to double check for consistency)
* Versioning? What happens if Zdog's JSON format changes in the future as new features are added?