### PR TITLE
Add unpkg field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "Round, flat, designer-friendly pseudo-3D engine",
   "main": "js/index.js",
+  "unpkg": "dist/zdog.dist.min.js",
   "files": [
     "dist/*.*",
     "js/*.*",


### PR DESCRIPTION
Hello! Zdog is amazing 😍

This PR adds an `unpkg` field, as recommended by [unpkg](https://unpkg.com) to correctly resolve the UMD build of the module. This means that, first, folks using d3-require automatically get the right version. And also, people can use `https://unpkg.com/zdog@1` to automatically get the right file for a given semver version range, even if you move around the dist file (so if you want to move `dist`, it's less likely to automatically be a major change. Plus, it'll make Zdog a bit easier to require on Observable!