### PR TITLE
fix window variable in dragger

### DIFF
--- a/js/dragger.js
+++ b/js/dragger.js
@@ -6,12 +6,12 @@
   // module definition
   if ( typeof module == 'object' && module.exports ) {
     // CommonJS
-    module.exports = factory( root );
+    module.exports = factory();
   } else {
     // browser global
-    root.Zdog.Dragger = factory( root );
+    root.Zdog.Dragger = factory();
   }
-}( this, function factory( window ) {
+}( this, function factory() {
 
 // quick & dirty drag event stuff
 // messes up if multiple pointers/touches


### PR DESCRIPTION
When using zdog in webpack or parcel, `this` is not assigned to `window`. Use global window instead of `this`. Also mentioned in #49 