### PR TITLE
getFlatGraph: rewrite recursion to while loop

### DIFF
--- a/js/anchor.js
+++ b/js/anchor.js
@@ -139,9 +139,17 @@ Anchor.prototype.updateFlatGraph = function() {
 };
 
 // return Array of self & all child graph items
-Anchor.prototype.getFlatGraph = function() {
-  var flatGraph = [ this ];
-  return this.addChildFlatGraph( flatGraph );
+Anchor.prototype.getFlatGraph = function () {
+  var flatGraph = [this];
+  var index = 0;
+  while (index < flatGraph.length) {
+    var currentGraph = flatGraph[index];
+    currentGraph.children.forEach(function (child) {
+      flatGraph.push(child);
+    });
+    index++;
+  }
+  return flatGraph;
 };
 
 Anchor.prototype.addChildFlatGraph = function( flatGraph ) {


### PR DESCRIPTION
To avoid call stack overflow when the graph has a large nesting depth.  For example:

```javascript
let illo = new Zdog.Illustration({
    element: '.canvas'
});

let parent = illo;
for (let depth = 0; depth < 1000; depth++) {

    let rotateX = new Zdog.Anchor({
        addTo: parent,
        rotate: { x: Zdog.TAU / 4 }
    });

    let rotateY = new Zdog.Anchor({
        addTo: rotateX,
        rotate: { y: Zdog.TAU / 6 }
    });

    let rotateZ = new Zdog.Anchor({
        addTo: rotateY,
        rotate: { z: Zdog.TAU / 8 }
    });

    parent = rotateZ;
}
```