### PR TITLE
Fix deduplication of objectKeys

### DIFF
--- a/js/anchor.js
+++ b/js/anchor.js
@@ -230,7 +230,7 @@ function getSubclass( Super ) {
     Item.optionKeys = Super.optionKeys.slice( 0 );
     // add defaults keys to optionKeys, dedupe
     Object.keys( Item.defaults ).forEach( function( key ) {
-      if ( !Item.optionKeys.indexOf( key ) != 1 ) {
+      if ( Item.optionKeys.indexOf( key ) === -1 ) {
         Item.optionKeys.push( key );
       }
     } );


### PR DESCRIPTION
This one conditional got improperly warped when it migrated away from `Array.includes()`.

In its current form it always pushes a new copy unless there's a match at precisely index array 1.

Doesn't really hurt anything but I noticed it while working on Yet Another Zdog WYSIWYG Editor using the optionKeys to automatically fill out editable properties.